### PR TITLE
CMakeList: changed absolute reference for win32, c:\program files...... ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ INSTALL(TARGETS ${PACKAGE_NAME} RUNTIME LIBRARY DESTINATION "/usr/local/lib/open
 ENDIF(UNIX)
 
 IF(WIN32)
-INSTALL(TARGETS ${PACKAGE_NAME} RUNTIME DESTINATION "c:/Program Files/opencpn/plugins")
+INSTALL(TARGETS ${PACKAGE_NAME} RUNTIME DESTINATION "plugins") 
 ENDIF(WIN32)
 
 # find src/ -name \*.cpp -or -name \*.c -or -name \*.h -or -name \*.hpp >po/POTFILES.in


### PR DESCRIPTION
Absolute reference in CmakeList is not allowed. I couldn't make the install package. 
