### PR TITLE
Correction for missing lines in shader image

### DIFF
--- a/src/br24radar_pi.cpp
+++ b/src/br24radar_pi.cpp
@@ -1773,7 +1773,7 @@ void br24radar_pi::PrepareRadarImage(int angle)
         if (shader_start_line == -1) {
             shader_start_line = angle;
         }
-        shader_end_line = angle;
+        shader_end_line = angle + 1;
 
         // zero out texture data
         if(settings.display_option)


### PR DESCRIPTION
Checking for 
shader_end_line == LINES_PER_ROTATION
is not required.