### PR TITLE
Start receive threads already in br24radar_pi::Init

### DIFF
--- a/src/br24radar_pi.cpp
+++ b/src/br24radar_pi.cpp
@@ -637,21 +637,18 @@ void br24radar_pi::DoTick( void )
         }
     }
 
-#if TODO
-    // This area is stil a mess, not sure what was intended here
+
+    // Check the age of "radar_seen", if too old radar_seen = false
+    time_t now1 = time(0);
     for (size_t r = 0; r < RADARS; r++) {
         if (m_radar[r]->radar_seen) {
-            if (TIMER_ELAPSED(now, m_radar[r].radar_watchdog)) {
+            if (now1 - m_radar[r]->radar_watchdog > ALARM_TIMEOUT) {   
                 m_radar[r]->radar_seen = false;
                 m_radar[r]->state.Update(RADAR_OFF);
                 wxLogMessage(wxT("BR24radar_pi: Lost %s presence"), m_radar[r]->name);
             }
-            else (m_radar[0]->radar_seen) {
-                if (m_radar[0]->transmit.RadarStayAlive()) {      // send stay alive to obtain control blocks from radar
-                    m_previous_radar_seen = true;
-                }
             }
-#endif
+        }
 
     bool any_data_seen = false;
     for (size_t r = 0; r < RADARS; r++) {
@@ -803,7 +800,7 @@ void br24radar_pi::UpdateState( void )
         radar_seen |= m_radar[r]->radar_seen;
         data_seen |= m_radar[r]->data_seen;
     }
-
+    wxLogMessage(wxT("BR24radar_pi: XXX update state %d  %d  %d"), m_radar[0]->radar_seen, m_radar[1]->radar_seen, radar_seen);
     if (!radar_seen || !m_opengl_mode) {
         m_toolbar_button = TB_RED;
         CacheSetToolbarToolBitmaps(BM_ID_RED, BM_ID_RED);

--- a/src/br24radar_pi.cpp
+++ b/src/br24radar_pi.cpp
@@ -227,6 +227,14 @@ int br24radar_pi::Init( void )
     ShowRadarControl(0, m_settings.show_radar == RADAR_ON);
     ShowRadarControl(1, m_settings.show_radar == RADAR_ON);
 
+    if (!m_radar[0]->receive) {
+        m_radar[0]->StartReceive();
+    }
+    if (!m_radar[1]->receive && m_settings.enable_dual_radar && m_radar[0]->radar_type == RT_4G) {
+        m_radar[1]->StartReceive();
+        m_radar[0]->SetName(_("Radar A"));
+    }
+
     return (WANTS_DYNAMIC_OPENGL_OVERLAY_CALLBACK |
             WANTS_OPENGL_OVERLAY_CALLBACK |
             WANTS_OVERLAY_CALLBACK     |

--- a/src/br24radar_pi.h
+++ b/src/br24radar_pi.h
@@ -420,7 +420,7 @@ private:
 
     bool                      m_guard_bogey_confirmed;
     time_t                    m_alarm_sound_last;
-#define     ALARM_TIMEOUT (10)
+#define     ALARM_TIMEOUT (5)
 };
 
 #include "br24OptionsDialog.h"


### PR DESCRIPTION
- avoid message "radar can not be started as..." while the radar is transmiting