### PR TITLE
Hide small blobs for ARPA

### DIFF
--- a/src/Kalman.cpp
+++ b/src/Kalman.cpp
@@ -48,8 +48,6 @@ KalmanFilter::KalmanFilter() {
   // Ai,j is jacobian matrix dfi / dxj
 
   I = I.Identity();
-  V = ZeroMatrix2;
-  VT = ZeroMatrix2;
   Q = ZeroMatrix2;
   R = ZeroMatrix2;
 
@@ -84,13 +82,8 @@ void KalmanFilter::ResetFilter() {
   HT = ZeroMatrix42;
 
   // Jacobian V, dhi / dvj
-
-  V(0, 0) = 1.;
-  V(1, 1) = 1.;
-
-  VT(0, 0) = 1.;
-  VT(1, 1) = 1.;
-
+  // As V is the identity matrix, it is left out of the calculation of the Kalman gain
+  
   // P estimate error covariance
   // initial values follow
   // P(1, 1) = .0000027 * range * range;   ???

--- a/src/Kalman.cpp
+++ b/src/Kalman.cpp
@@ -121,9 +121,15 @@ void KalmanFilter::Predict(LocalPosition* xx, double delta_time) {
   xx->lon = X(1, 0);
   xx->dlat_dt = X(2, 0);
   xx->dlon_dt = X(3, 0);
-  // calculate apriori P
-  P = A * P * AT + W * Q * WT;
   xx->sd_speed_m_s = sqrt((P(2, 2) + P(3, 3)) / 2.);  // rough approximation of standard dev of speed
+ return;
+}
+
+void KalmanFilter::Update_P() {  
+    // calculate apriori P  
+    // separated from the predict to prevent the update being done both in pass 1 and pass2
+    
+  P = A * P * AT + W * Q * WT;
   return;
 }
 

--- a/src/Kalman.cpp
+++ b/src/Kalman.cpp
@@ -83,7 +83,7 @@ void KalmanFilter::ResetFilter() {
 
   // Jacobian V, dhi / dvj
   // As V is the identity matrix, it is left out of the calculation of the Kalman gain
-  
+
   // P estimate error covariance
   // initial values follow
   // P(1, 1) = .0000027 * range * range;   ???
@@ -122,13 +122,13 @@ void KalmanFilter::Predict(LocalPosition* xx, double delta_time) {
   xx->dlat_dt = X(2, 0);
   xx->dlon_dt = X(3, 0);
   xx->sd_speed_m_s = sqrt((P(2, 2) + P(3, 3)) / 2.);  // rough approximation of standard dev of speed
- return;
+  return;
 }
 
-void KalmanFilter::Update_P() {  
-    // calculate apriori P  
-    // separated from the predict to prevent the update being done both in pass 1 and pass2
-    
+void KalmanFilter::Update_P() {
+  // calculate apriori P
+  // separated from the predict to prevent the update being done both in pass 1 and pass2
+
   P = A * P * AT + W * Q * WT;
   return;
 }

--- a/src/Kalman.h
+++ b/src/Kalman.h
@@ -37,7 +37,7 @@
 
 PLUGIN_BEGIN_NAMESPACE
 
-#define NOISE (0.02)  // Allowed covariance of target speed in lat and lon
+#define NOISE (0.015)  // Allowed covariance of target speed in lat and lon
                       // critical for the performance of target tracking
                       // lower value makes target go straight
                       // higher values allow target to make curves

--- a/src/Kalman.h
+++ b/src/Kalman.h
@@ -71,6 +71,7 @@ class KalmanFilter {
   void SetMeasurement(Polar* p, LocalPosition* x, Polar* expected, int range);
   void Predict(LocalPosition* x, double delta_time);  // measured position and expected position
   void ResetFilter();
+  void Update_P();
 
   Matrix<double, 4> A;
   Matrix<double, 4> AT;

--- a/src/Kalman.h
+++ b/src/Kalman.h
@@ -37,7 +37,7 @@
 
 PLUGIN_BEGIN_NAMESPACE
 
-#define NOISE (0.13)  // Allowed covariance of target speed in lat and lon
+#define NOISE (0.02)  // Allowed covariance of target speed in lat and lon
                       // critical for the performance of target tracking
                       // lower value makes target go straight
                       // higher values allow target to make curves
@@ -78,8 +78,6 @@ class KalmanFilter {
   Matrix<double, 2, 4> WT;
   Matrix<double, 2, 4> H;
   Matrix<double, 4, 2> HT;
-  Matrix<double, 2> V;
-  Matrix<double, 2> VT;
   Matrix<double, 4> P;
   Matrix<double, 2> Q;
   Matrix<double, 2> R;

--- a/src/RadarInfo.h
+++ b/src/RadarInfo.h
@@ -139,6 +139,7 @@ class RadarInfo : public wxEvtHandler {
   radar_control_item m_boot_state;  // Can contain RADAR_TRANSMIT until radar is seen at boot
 
   radar_control_item m_orientation;  // 0 = Heading Up, 1 = North Up
+  int m_min_contour_length;    // minimum contour length of an ARPA or MARPA target
 #define ORIENTATION_HEAD_UP (0)
 #define ORIENTATION_NORTH_UP (1)
 #define ORIENTATION_COURSE_UP (2)

--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -223,7 +223,7 @@ bool RadarArpa::MultiPix(int ang, int rad) {
   // false if not
   // if false clears out pixels of th blob in hist
   //    wxCriticalSectionLocker lock(ArpaTarget::m_ri->m_exclusive);
-    int length = m_ri->m_min_contour_length;
+  int length = m_ri->m_min_contour_length;
   Polar start;
   start.angle = ang;
   start.r = rad;
@@ -797,7 +797,7 @@ void ArpaTarget::RefreshTarget(int dist) {
 
     // Kalman filter to  calculate the apostriori local position and speed based on found position (pol)
     if (m_status > 1) {
-        m_kalman->Update_P();
+      m_kalman->Update_P();
       m_kalman->SetMeasurement(&pol, &x_local, &m_expected, m_ri->m_range_meters);  // pol is measured position in polar coordinates
     }
 
@@ -809,7 +809,7 @@ void ArpaTarget::RefreshTarget(int dist) {
   // target not found
   else {
     // target not found
-      if (m_pass_nr == PASS1) m_kalman->Update_P();
+    if (m_pass_nr == PASS1) m_kalman->Update_P();
     // check if the position of the target has been taken by another target, a duplicate
     // if duplicate, handle target as not found but don't do pass 2 (= search in the surroundings)
     bool duplicate = false;
@@ -1174,6 +1174,5 @@ void ArpaTarget::ResetPixels() {
     }
   }
 }
-
 
 PLUGIN_END_NAMESPACE

--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -692,8 +692,6 @@ void ArpaTarget::RefreshTarget(int dist) {
     m_speed_kn = (sqrt(s1 * s1 + s2 * s2)) * 3600. / 1852.;  // and convert to nautical miles per hour
     m_course = rad2deg(atan2(s2, s1));
     if (m_course < 0) m_course += 360.;
-
-    GetSpeed();
     if (m_speed_kn > 20.) {
       pol = Pos2Polar(m_position, own_pos, m_ri->m_range_meters);
     }
@@ -871,8 +869,8 @@ void ArpaTarget::PassARPAtoOCPN(Polar* pol, OCPN_target_status status) {
 
   if (bearing < 0) bearing += 360;
   s_TargID = wxString::Format(wxT("%4i"), m_target_id);
-  s_speed = wxString::Format(wxT("%4.2f"), status == Q ? 0.0 : m_speed_kn);
-  s_course = wxString::Format(wxT("%3.1f"), status == Q ? 0.0 : m_course);
+  s_speed = wxString::Format(wxT("%4.2f"), m_speed_kn);
+  s_course = wxString::Format(wxT("%3.1f"), m_course);
   if (m_automatic) {
     s_target_name = wxString::Format(wxT("ARPA%4i"), m_target_id);
   } else {
@@ -990,21 +988,5 @@ void ArpaTarget::ResetPixels() {
   }
 }
 
-void ArpaTarget::GetSpeed() {
-  m_speeds.nr++;
-  if (m_speeds.nr > SPEED_HISTORY) m_speeds.nr = SPEED_HISTORY;
-  // shift array down
-  int num = sizeof(double) * (SPEED_HISTORY - 1);
-  memmove(&m_speeds.hist[1], m_speeds.hist, num);
-  // set last speed
-  m_speeds.hist[0] = m_speed_kn;
-  // calculate average
-  m_speeds.av = 0.;
-  for (int i = 0; i < m_speeds.nr; i++) {
-    m_speeds.av += m_speeds.hist[i];
-  }
-  m_speeds.av /= m_speeds.nr;
-  m_speed_kn = m_speeds.av;
-  m_position.speed_kn = m_speed_kn;
-}
+
 PLUGIN_END_NAMESPACE

--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -715,9 +715,8 @@ void ArpaTarget::RefreshTarget(int dist) {
   if ((time1 < (m_refresh + SCAN_MARGIN2) || time2 < time1) && m_status != 0) {
     wxLongLong now = wxGetUTCTimeMillis();  // millis
     int diff = now.GetLo() - m_refresh.GetLo();
-    if (diff > 5200) {
-      LOG_INFO(wxT("BR24radar_pi: target not refreshed, missing spokes status= %i, target_id= %i, lost_countx= %i timediff= %i"),
-          m_status, m_target_id, m_lost_count, diff);
+    if (diff > 8000) {
+      LOG_INFO(wxT("BR24radar_pi: target not refreshed, missing spokes, set lost, status= %i, target_id= %i timediff= %i"), m_status, m_target_id, diff);
       SetStatusLost();
     }
     return;

--- a/src/RadarMarpa.h
+++ b/src/RadarMarpa.h
@@ -68,7 +68,6 @@ class Position;
 #define T_NUM (6)  // status T to OCPN at target status
 #define SPEED_HISTORY (8)
 #define TARGET_SPEED_DIV_SDEV 2.
-#define MAX_DUP 2                     // maximum number of sweeps a duplicate target is allowed to exist
 #define STATUS_TO_OCPN (5)            // First status to be send to OCPN
 #define START_UP_SPEED (0.5)          // maximum allowed speed (m/sec) for new target, real format with .
 #define DISTANCE_BETWEEN_TARGETS (4)  // minimum separation between targets

--- a/src/RadarMarpa.h
+++ b/src/RadarMarpa.h
@@ -53,7 +53,7 @@ class Position;
 #define SCAN_MARGIN2 (1000)          // if target is refreshed after this time you will be shure it is the next sweep
 #define MAX_CONTOUR_LENGTH (601)     // defines maximal size of target contour
 #define MAX_TARGET_DIAMETER (200)    // target will be set lost if diameter larger than this value
-#define MAX_LOST_COUNT (3)  // number of sweeps that target can be missed before it is seet to lost
+#define MAX_LOST_COUNT (3)           // number of sweeps that target can be missed before it is seet to lost
 
 #define FOR_DELETION (-2)  // status of a duplicate target used to delete a target
 #define LOST (-1)

--- a/src/RadarMarpa.h
+++ b/src/RadarMarpa.h
@@ -53,7 +53,7 @@ class Position;
 #define SCAN_MARGIN2 (1000)          // if target is refreshed after this time you will be shure it is the next sweep
 #define MAX_CONTOUR_LENGTH (601)     // defines maximal size of target contour
 #define MAX_TARGET_DIAMETER (200)    // target will be set lost if diameter larger than this value
-#define MIN_CONTOUR_LENGTH (8)
+#define MIN_CONTOUR_LENGTH (6)       // target with a circumference smaller will not be seen at all
 #define MAX_LOST_COUNT (3)  // number of sweeps that target can be missed before it is seet to lost
 
 #define FOR_DELETION (-2)  // status of a duplicate target used to delete a target

--- a/src/RadarMarpa.h
+++ b/src/RadarMarpa.h
@@ -53,7 +53,6 @@ class Position;
 #define SCAN_MARGIN2 (1000)          // if target is refreshed after this time you will be shure it is the next sweep
 #define MAX_CONTOUR_LENGTH (601)     // defines maximal size of target contour
 #define MAX_TARGET_DIAMETER (200)    // target will be set lost if diameter larger than this value
-#define MIN_CONTOUR_LENGTH (6)       // target with a circumference smaller will not be seen at all
 #define MAX_LOST_COUNT (3)  // number of sweeps that target can be missed before it is seet to lost
 
 #define FOR_DELETION (-2)  // status of a duplicate target used to delete a target

--- a/src/br24radar_pi.cpp
+++ b/src/br24radar_pi.cpp
@@ -1075,6 +1075,7 @@ bool br24radar_pi::LoadConfig(void) {
         m_radar[r]->m_orientation.Update(v);
         pConf->Read(wxString::Format(wxT("Radar%dTransmit"), r), &v, 0);
         m_radar[r]->m_boot_state.Update(v);
+        pConf->Read(wxString::Format(wxT("Radar%dMinContourLength"), r), &m_radar[r]->m_min_contour_length, 6);
 
         pConf->Read(wxString::Format(wxT("Radar%dTrails"), r), &v, 0);
         SetControlValue(r, CT_TARGET_TRAILS, v);
@@ -1216,6 +1217,7 @@ bool br24radar_pi::SaveConfig(void) {
       pConf->Write(wxString::Format(wxT("Radar%dWindowPosY"), r), m_settings.window_pos[r].y);
       pConf->Write(wxString::Format(wxT("Radar%dControlPosX"), r), m_settings.control_pos[r].x);
       pConf->Write(wxString::Format(wxT("Radar%dControlPosY"), r), m_settings.control_pos[r].y);
+      pConf->Write(wxString::Format(wxT("Radar%dMinContourLength"), r), m_radar[r]->m_min_contour_length);
 
       // LOG_DIALOG(wxT("BR24radar_pi: SaveConfig: show_radar[%d]=%d"), r, m_settings.show_radar[r]);
       for (int i = 0; i < GUARD_ZONES; i++) {


### PR DESCRIPTION
The minimum contour length of a target can now per radar be specified in the ini file (Radar0MinContourLength). Blobs with a contour below this value will be ignored by the (M)ARPA system. This should make it possible to follow targets in a cluttered environment, as long as the targets are larger than the clutter.