### PR TITLE
Deleted AIS/ARPA debug info

### DIFF
--- a/src/br24radar_pi.h
+++ b/src/br24radar_pi.h
@@ -477,7 +477,6 @@ class br24radar_pi : public opencpn_plugin_112 {
   time_t m_idle_transmit;  // When we will change to transmit
 
   // Check for AIS targets inside ARPA zone
-  wxString JsonAIS;  // Temp for Json AIS message
   AisArpa ais_in_arpa[SIZEAISAR];
   int count_ais_in_arpa;
   bool FindAIS_at_arpaPos(const double &lat, const double &lon, const double &dist);


### PR DESCRIPTION
Debug info used for AIS detection is now needless. The function seems to work as desired.