### PR TITLE
Redundant call removed

### DIFF
--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -975,7 +975,6 @@ ArpaTarget::ArpaTarget(br24radar_pi* pi, RadarInfo* ri) {
   m_stationary = 0;
   m_position.dlat_dt = 0.;
   m_position.dlon_dt = 0.;
-  m_speeds.nr = 0;
   m_pass1_result = UNKNOWN;
   m_pass_nr = PASS1;
 }
@@ -993,7 +992,6 @@ ArpaTarget::ArpaTarget() {
   m_stationary = 0;
   m_position.dlat_dt = 0.;
   m_position.dlon_dt = 0.;
-  m_speeds.nr = 0;
   m_pass1_result = UNKNOWN;
   m_pass_nr = PASS1;
 }
@@ -1115,7 +1113,6 @@ void ArpaTarget::SetStatusLost() {
   m_stationary = 0;
   m_position.dlat_dt = 0.;
   m_position.dlon_dt = 0.;
-  m_speeds.nr = 0;
   m_pass_nr = PASS1;
 }
 

--- a/src/RadarMarpa.h
+++ b/src/RadarMarpa.h
@@ -65,7 +65,6 @@ class Position;
 
 #define Q_NUM (4)  // status Q to OCPN at target status
 #define T_NUM (6)  // status T to OCPN at target status
-#define SPEED_HISTORY (8)
 #define TARGET_SPEED_DIV_SDEV 2.
 #define STATUS_TO_OCPN (5)            // First status to be send to OCPN
 #define START_UP_SPEED (0.5)          // maximum allowed speed (m/sec) for new target, real format with .
@@ -92,14 +91,6 @@ class Position {
 Position Polar2Pos(Polar pol, Position own_ship, double range);
 
 Polar Pos2Polar(Position p, Position own_ship, int range);
-
-struct SpeedHistory {
-  double av;
-  double hist[SPEED_HISTORY];
-  double dif[SPEED_HISTORY];
-  double sd;
-  int nr;
-};
 
 enum TargetProcessStatus { UNKNOWN, NOT_FOUND_IN_PASS1 };
 enum PassN { PASS1, PASS2 };
@@ -135,7 +126,6 @@ class ArpaTarget {
   double m_speed_kn;     // Average speed of target. TODO: Merge with m_position.speed?
   wxLongLong m_refresh;  // time of last refresh
   double m_course;
-  SpeedHistory m_speeds;
   int m_stationary;  // number of sweeps target was stationary
   int m_lost_count;
   bool m_check_for_duplicate;

--- a/src/br24Receive.cpp
+++ b/src/br24Receive.cpp
@@ -263,13 +263,13 @@ void br24Receive::ProcessFrame(const UINT8 *data, int len) {
     if (radar_heading_valid && !m_pi->m_settings.ignore_radar_heading) {
       heading = MOD_DEGREES(SCALE_RAW_TO_DEGREES(MOD_ROTATION(heading_raw)));
       m_pi->SetRadarHeading(heading, radar_heading_true);
-    } else {  // no heading on radar
-      if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT)
-        m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
+    } else if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT) {
+      // no heading on radar
+      m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
       m_pi->SetRadarHeading();
-      // Guess the heading for the spoke. This is updated much less frequently than the
-      // data from the radar (which is accurate 10x per second), likely once per second.
     }
+    // Guess the heading for the spoke. This is updated much less frequently than the
+    // data from the radar (which is accurate 10x per second), likely once per second.
     heading_raw = SCALE_DEGREES_TO_RAW(m_pi->GetHeadingTrue());  // include variation
     bearing_raw = angle_raw + heading_raw;
     // until here all is based on 4096 (SPOKES) scanlines

--- a/src/br24Receive.cpp
+++ b/src/br24Receive.cpp
@@ -264,7 +264,7 @@ void br24Receive::ProcessFrame(const UINT8 *data, int len) {
       heading = MOD_DEGREES(SCALE_RAW_TO_DEGREES(MOD_ROTATION(heading_raw)));
       m_pi->SetRadarHeading(heading, radar_heading_true);
     } else if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT) {
-      // no heading on radar
+      // no heading on radar and heading source is still radar
       m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
       m_pi->SetRadarHeading();
     }


### PR DESCRIPTION
Correction:
    m_pi->SetRadarHeading(); was called unnecessarily when there is no heading on radar. These calls had no effect, but caused delay.