### PR TITLE
Offset of radar antenna and GPS antenna

### DIFF
--- a/src/GuardZone.cpp
+++ b/src/GuardZone.cpp
@@ -180,8 +180,8 @@ void GuardZone::SearchTargets() {
             Polar pol;
             pol.angle = angle;
             pol.r = rrr;
-            own_pos.lat = m_pi->m_ownship_lat;
-            own_pos.lon = m_pi->m_ownship_lon;
+            own_pos.lat = m_pi->m_radar_lat;
+            own_pos.lon = m_pi->m_radar_lon;
             Position x;
             x = Polar2Pos(pol, own_pos, m_ri->m_range_meters);
             int target_i;

--- a/src/RadarCanvas.cpp
+++ b/src/RadarCanvas.cpp
@@ -305,8 +305,8 @@ void RadarCanvas::RenderCursor(int w, int h) {
       return;
     }
     // Can't compute this upfront, ownship may move...
-    distance = local_distance(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_ri->m_mouse_lat, m_ri->m_mouse_lon) * 1852.;
-    bearing = local_bearing(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_ri->m_mouse_lat, m_ri->m_mouse_lon);
+    distance = local_distance(m_pi->m_radar_lat, m_pi->m_radar_lon, m_ri->m_mouse_lat, m_ri->m_mouse_lon) * 1852.;
+    bearing = local_bearing(m_pi->m_radar_lat, m_pi->m_radar_lon, m_ri->m_mouse_lat, m_ri->m_mouse_lon);
     if (m_ri->GetOrientation() != ORIENTATION_NORTH_UP) {
       bearing -= m_pi->GetHeadingTrue();
     }
@@ -445,8 +445,8 @@ void RadarCanvas::Render(wxPaintEvent &evt) {
     glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 
     PlugIn_ViewPort vp;
-    vp.clat = m_pi->m_ownship_lat;
-    vp.clon = m_pi->m_ownship_lon;
+    vp.clat = m_pi->m_radar_lat;
+    vp.clon = m_pi->m_radar_lon;
     vp.m_projection_type = 4;  // Orthographic projection
     float full_range = wxMax(w, h) / 2.0;
     int display_range = m_ri->GetDisplayRange();

--- a/src/RadarInfo.cpp
+++ b/src/RadarInfo.cpp
@@ -465,6 +465,9 @@ void RadarInfo::ProcessRadarSpoke(SpokeBearing angle, SpokeBearing bearing, UINT
   // Why don't we make this an option? Yes we should
   data[RETURNS_PER_LINE - 1] = 200;  //  range ring, do we want this? ActionL: make setting, switched on for testing
 
+  data[2] = 200; // dot in the centre
+  data[1] = 200;
+
   if (m_range_meters != range_meters) {
     ResetSpokes();
     if (m_arpa) {
@@ -745,17 +748,17 @@ void RadarInfo::UpdateTrailPosition() {
   if (!m_pi->m_bpos_set || m_pi->m_heading_source == HEADING_NONE) {
     return;
   }
-  if (m_trails.lat == m_pi->m_ownship_lat && m_trails.lon == m_pi->m_ownship_lon) {  // don't do anything until position changes
+  if (m_trails.lat == m_pi->m_radar_lat && m_trails.lon == m_pi->m_radar_lon) {  // don't do anything until position changes
     return;
   }
 
-  double dif_lat = m_pi->m_ownship_lat - m_trails.lat;  // going north is positive
-  double dif_lon = m_pi->m_ownship_lon - m_trails.lon;  // moving east is positive
-  m_trails.lat = m_pi->m_ownship_lat;
-  m_trails.lon = m_pi->m_ownship_lon;
+  double dif_lat = m_pi->m_radar_lat - m_trails.lat;  // going north is positive
+  double dif_lon = m_pi->m_radar_lon - m_trails.lon;  // moving east is positive
+  m_trails.lat = m_pi->m_radar_lat;
+  m_trails.lon = m_pi->m_radar_lon;
   double fshift_lat = dif_lat * 60. * 1852. / (double)m_range_meters * (double)(RETURNS_PER_LINE);
   double fshift_lon = dif_lon * 60. * 1852. / (double)m_range_meters * (double)(RETURNS_PER_LINE);
-  fshift_lon *= cos(deg2rad(m_pi->m_ownship_lat));  // at higher latitudes a degree of longitude is fewer meters
+  fshift_lon *= cos(deg2rad(m_pi->m_radar_lat));  // at higher latitudes a degree of longitude is fewer meters
   int shift_lat = (int)(fshift_lat + m_trails.dif_lat);
 
   if (shift_lat > 0 && m_dir_lat <= 0) {
@@ -796,8 +799,8 @@ void RadarInfo::UpdateTrailPosition() {
 
   if (abs(shift_lat) >= MARGIN || abs(shift_lon) >= MARGIN) {  // huge shift, reset trails
     ClearTrails();
-    m_trails.lat = m_pi->m_ownship_lat;
-    m_trails.lon = m_pi->m_ownship_lon;
+    m_trails.lat = m_pi->m_radar_lat;
+    m_trails.lon = m_pi->m_radar_lon;
     m_trails.dif_lat = 0.;
     m_trails.dif_lon = 0.;
     LOG_INFO(wxT("BR24radar_pi: %s Large movement trails reset"), m_name.c_str());
@@ -1325,8 +1328,8 @@ wxString RadarInfo::GetCanvasTextBottomLeft() {
 
     } else if (!isnan(m_mouse_lat) && !isnan(m_mouse_lon) && m_pi->m_bpos_set) {
       // Can't compute this upfront, ownship may move...
-      distance = local_distance(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_mouse_lat, m_mouse_lon);
-      bearing = local_bearing(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_mouse_lat, m_mouse_lon);
+      distance = local_distance(m_pi->m_radar_lat, m_pi->m_radar_lon, m_mouse_lat, m_mouse_lon);
+      bearing = local_bearing(m_pi->m_radar_lat, m_pi->m_radar_lon, m_mouse_lat, m_mouse_lon);
       if (GetOrientation() != ORIENTATION_NORTH_UP) {
         bearing -= m_pi->GetHeadingTrue();
       }
@@ -1466,8 +1469,8 @@ void RadarInfo::SetMouseVrmEbl(double vrm, double ebl) {
   double brng = deg2rad(bearing);
   double d = vrm;  // Distance in nm
 
-  double lat1 = deg2rad(m_pi->m_ownship_lat);
-  double lon1 = deg2rad(m_pi->m_ownship_lon);
+  double lat1 = deg2rad(m_pi->m_radar_lat);
+  double lon1 = deg2rad(m_pi->m_radar_lon);
 
   double lat2 = asin(sin(lat1) * cos(d / R) + cos(lat1) * sin(d / R) * cos(brng));
   double lon2 = lon1 + atan2(sin(brng) * sin(d / R) * cos(lat1), cos(d / R) - sin(lat1) * sin(lat2));
@@ -1492,8 +1495,8 @@ void RadarInfo::SetBearing(int bearing) {
       m_ebl[i][bearing] = m_mouse_ebl[i];
     }
   } else if (!isnan(m_mouse_lat) && !isnan(m_mouse_lon)) {
-    m_vrm[bearing] = local_distance(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_mouse_lat, m_mouse_lon);
-    m_ebl[orientation][bearing] = local_bearing(m_pi->m_ownship_lat, m_pi->m_ownship_lon, m_mouse_lat, m_mouse_lon);
+    m_vrm[bearing] = local_distance(m_pi->m_radar_lat, m_pi->m_radar_lon, m_mouse_lat, m_mouse_lon);
+    m_ebl[orientation][bearing] = local_bearing(m_pi->m_radar_lat, m_pi->m_radar_lon, m_mouse_lat, m_mouse_lon);
   }
 }
 

--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -693,8 +693,8 @@ void ArpaTarget::RefreshTarget(int dist) {
   if (m_status == LOST) {
     return;
   }
-  own_pos.lat = m_pi->m_ownship_lat;
-  own_pos.lon = m_pi->m_ownship_lon;
+  own_pos.lat = m_pi->m_radar_lat;
+  own_pos.lon = m_pi->m_radar_lon;
   pol = Pos2Polar(m_position, own_pos, m_ri->m_range_meters);
   wxLongLong time1 = m_ri->m_history[MOD_ROTATION2048(pol.angle)].time;
   int margin = SCAN_MARGIN;
@@ -1134,8 +1134,8 @@ int RadarArpa::AcquireNewARPATarget(Polar pol, int status) {
   // constructs Kalman filter
   Position own_pos;
   Position target_pos;
-  own_pos.lat = m_pi->m_ownship_lat;
-  own_pos.lon = m_pi->m_ownship_lon;
+  own_pos.lat = m_pi->m_radar_lat;
+  own_pos.lon = m_pi->m_radar_lon;
   target_pos = Polar2Pos(pol, own_pos, m_ri->m_range_meters);
   // make new target or re-use an existing one with status == lost
   int i;

--- a/src/br24ControlsDialog.cpp
+++ b/src/br24ControlsDialog.cpp
@@ -58,6 +58,8 @@ enum {  // process ID's
 
   ID_BEARING_ALIGNMENT,
   ID_ANTENNA_HEIGHT,
+  ID_ANTENNA_FORWARD,
+  ID_ANTENNA_STARBOARD,
   ID_LOCAL_INTERFERENCE_REJECTION,
   ID_SIDE_LOBE_SUPPRESSION,
   ID_MAIN_BANG_SIZE,
@@ -133,6 +135,8 @@ EVT_BUTTON(ID_PREFERENCES, br24ControlsDialog::OnPreferencesButtonClick)
 
 EVT_BUTTON(ID_BEARING_ALIGNMENT, br24ControlsDialog::OnRadarControlButtonClick)
 EVT_BUTTON(ID_ANTENNA_HEIGHT, br24ControlsDialog::OnRadarControlButtonClick)
+EVT_BUTTON(ID_ANTENNA_FORWARD, br24ControlsDialog::OnRadarControlButtonClick)
+EVT_BUTTON(ID_ANTENNA_STARBOARD, br24ControlsDialog::OnRadarControlButtonClick)
 EVT_BUTTON(ID_LOCAL_INTERFERENCE_REJECTION, br24ControlsDialog::OnRadarControlButtonClick)
 EVT_BUTTON(ID_SIDE_LOBE_SUPPRESSION, br24ControlsDialog::OnRadarControlButtonClick)
 EVT_BUTTON(ID_MAIN_BANG_SIZE, br24ControlsDialog::OnRadarControlButtonClick)
@@ -471,6 +475,8 @@ void br24ControlsDialog::CreateControls() {
   label << _("Installation") << wxT("\n");
   label << _("Bearing alignment") << wxT("\n");
   label << _("Antenna height") << wxT("\n");
+  label << _("Antenna forward of GPS") << wxT("\n");
+  label << _("Antenna starboard of GPS") << wxT("\n");
   label << _("Local interference rej.") << wxT("\n");
   label << _("Side lobe suppression") << wxT("\n");
   label << _("Main bang size") << wxT("\n");
@@ -709,6 +715,20 @@ void br24ControlsDialog::CreateControls() {
   m_installation_sizer->Add(m_antenna_height_button, 0, wxALL, BORDER);
   m_antenna_height_button->minValue = 0;
   m_antenna_height_button->maxValue = 30;
+
+  // The ANTENNA FORWARD button
+  m_antenna_forward_button = new br24RadarControlButton(this, ID_ANTENNA_FORWARD, _("Antenna forward of GPS"), CT_ANTENNA_FORWARD, false,
+      m_pi->m_settings.antenna_forward);
+  m_installation_sizer->Add(m_antenna_forward_button, 0, wxALL, BORDER);
+  m_antenna_forward_button->minValue = -200;
+  m_antenna_forward_button->maxValue = 200;
+
+  // The ANTENNA STARBOARD button
+  m_antenna_starboard_button = new br24RadarControlButton(this, ID_ANTENNA_STARBOARD, _("Antenna starboard of GPS"), CT_ANTENNA_STARBOARD, false,
+      m_pi->m_settings.antenna_starboard);
+  m_installation_sizer->Add(m_antenna_starboard_button, 0, wxALL, BORDER);
+  m_antenna_starboard_button->minValue = -200;
+  m_antenna_starboard_button->maxValue = 200;
 
   // The LOCAL INTERFERENCE REJECTION button
   m_local_interference_rejection_button = new br24RadarControlButton(
@@ -1647,6 +1667,8 @@ void br24ControlsDialog::UpdateControlValues(bool refreshAll) {
     m_timed_run_button->SetLocalValue(M_SETTINGS.idle_run_time);
     m_refresh_rate_button->SetLocalValue(M_SETTINGS.refreshrate);
     m_main_bang_size_button->SetLocalValue(M_SETTINGS.main_bang_size);
+    m_antenna_starboard_button->SetLocalValue(M_SETTINGS.antenna_starboard);
+    m_antenna_forward_button->SetLocalValue(M_SETTINGS.antenna_forward);
   }
 
   // Update the text that is currently shown in the edit box, this is a copy of the button itself

--- a/src/br24ControlsDialog.h
+++ b/src/br24ControlsDialog.h
@@ -183,6 +183,8 @@ class br24ControlsDialog : public wxDialog {
   // Installation controls
   br24RadarControlButton *m_bearing_alignment_button;
   br24RadarControlButton *m_antenna_height_button;
+  br24RadarControlButton *m_antenna_forward_button;
+  br24RadarControlButton *m_antenna_starboard_button;
   br24RadarControlButton *m_local_interference_rejection_button;
   br24RadarControlButton *m_side_lobe_suppression_button;
   br24RadarControlButton *m_main_bang_size_button;

--- a/src/br24Receive.cpp
+++ b/src/br24Receive.cpp
@@ -263,13 +263,13 @@ void br24Receive::ProcessFrame(const UINT8 *data, int len) {
     if (radar_heading_valid && !m_pi->m_settings.ignore_radar_heading) {
       heading = MOD_DEGREES(SCALE_RAW_TO_DEGREES(MOD_ROTATION(heading_raw)));
       m_pi->SetRadarHeading(heading, radar_heading_true);
-    } else {  // no heading on radar
-      if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT)
-        m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
+    } else if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT) {
+      // no heading on radar
+      m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
       m_pi->SetRadarHeading();
-      // Guess the heading for the spoke. This is updated much less frequently than the
-      // data from the radar (which is accurate 10x per second), likely once per second.
     }
+    // Guess the heading for the spoke. This is updated much less frequently than the
+    // data from the radar (which is accurate 10x per second), likely once per second.
     heading_raw = SCALE_DEGREES_TO_RAW(m_pi->GetHeadingTrue());  // include variation
     bearing_raw = angle_raw + heading_raw;
     // until here all is based on 4096 (SPOKES) scanlines

--- a/src/br24Receive.cpp
+++ b/src/br24Receive.cpp
@@ -157,8 +157,8 @@ void br24Receive::logBinaryData(const wxString &what, const UINT8 *data, int siz
 //
 void br24Receive::ProcessFrame(const UINT8 *data, int len) {
   time_t now = time(0);
-  double lat = m_pi->m_ownship_lat;
-  double lon = m_pi->m_ownship_lon;
+  double lat = m_pi->m_radar_lat;
+  double lon = m_pi->m_radar_lon;
   // log_line.time_rec = wxGetUTCTimeMillis();
   wxLongLong time_rec = wxGetUTCTimeMillis();
 

--- a/src/br24Receive.cpp
+++ b/src/br24Receive.cpp
@@ -264,7 +264,7 @@ void br24Receive::ProcessFrame(const UINT8 *data, int len) {
       heading = MOD_DEGREES(SCALE_RAW_TO_DEGREES(MOD_ROTATION(heading_raw)));
       m_pi->SetRadarHeading(heading, radar_heading_true);
     } else if (m_pi->m_heading_source == HEADING_RADAR_HDM || m_pi->m_heading_source == HEADING_RADAR_HDT) {
-      // no heading on radar
+      // no heading on radar and heading source is still radar
       m_pi->m_heading_source = HEADING_NONE;  // let other heading source take over
       m_pi->SetRadarHeading();
     }

--- a/src/br24Transmit.cpp
+++ b/src/br24Transmit.cpp
@@ -167,6 +167,8 @@ bool br24Transmit::SetControlValue(ControlType controlType, int value, int autoV
     case CT_TRAILS_MOTION:
     case CT_MAIN_BANG_SIZE:
     case CT_MAX:
+    case CT_ANTENNA_FORWARD:
+    case CT_ANTENNA_STARBOARD:
       // The above are not settings that are not radar commands. Made them explicit so the
       // compiler can catch missing control types.
       break;

--- a/src/br24radar_pi.h
+++ b/src/br24radar_pi.h
@@ -168,6 +168,8 @@ typedef enum ControlType {
   CT_BEARING_ALIGNMENT,
   CT_SIDE_LOBE_SUPPRESSION,
   CT_ANTENNA_HEIGHT,
+  CT_ANTENNA_FORWARD,
+  CT_ANTENNA_STARBOARD,
   CT_LOCAL_INTERFERENCE_REJECTION,
   CT_TARGET_TRAILS,
   CT_TRAILS_MOTION,
@@ -194,6 +196,8 @@ static string ControlTypeNames[CT_MAX] = {"Range",
                                           "Bearing alignment",
                                           "Side lobe suppression",
                                           "Antenna height",
+                                          "Antenna forward of GPS",
+                                          "Antenna starboard of GPS"
                                           "Local interference rejection",
                                           "Target trails",
                                           "Target trails motion",
@@ -313,6 +317,8 @@ struct PersistentSettings {
   int threshold_blue;               // Radar data has to be this strong to show as WEAK
   int threshold_multi_sweep;        // Radar data has to be this strong not to be ignored in multisweep
   int main_bang_size;               // Pixels at center to ignore
+  int antenna_starboard;            // Ofsett of radar antenne starboard of GPS antenna
+  int antenna_forward;              // Ofsett of radar antenne forward of GPS antenna
   int type_detection_method;        // 0 = default, 1 = ignore reports
   int AISatARPAoffset;              // Rectangle side where to search AIS targets at ARPA position
   wxPoint control_pos[RADARS];      // Saved position of control menu windows
@@ -476,7 +482,7 @@ class br24radar_pi : public opencpn_plugin_114 {
 
   // Cursor position. Used to show position in radar window
   double m_cursor_lat, m_cursor_lon;
-  double m_ownship_lat, m_ownship_lon;
+  double m_ownship_lat, m_ownship_lon, m_radar_lat, m_radar_lon;
 
   bool m_initialized;      // True if Init() succeeded and DeInit() not called yet.
   bool m_first_init;       // True in first Init() call.


### PR DESCRIPTION
Offset of radar antenna and GPS antenna added
    - in installation menu
    - use radar position instead of own position everywhere
    - radar position updated in Notify

Also added: small circle in center of radar image to identify position of radar. Would a cross be nicer? (RadarInfo,cpp 468)