### PR TITLE
Bug: When in preferences "guardzone on overlay" = off

### DIFF
--- a/src/RadarMarpa.cpp
+++ b/src/RadarMarpa.cpp
@@ -669,13 +669,9 @@ void RadarArpa::RefreshArpaTargets() {
     m_targets[i]->RefreshTarget(dist);
   }
 
-  if (m_pi->m_settings.guard_zone_on_overlay) {
-    m_ri->m_guard_zone[0]->SearchTargets();
+  for (int i = 0; i < GUARD_ZONES; i++)
+    m_ri->m_guard_zone[i]->SearchTargets();
   }
-  if (m_pi->m_settings.guard_zone_on_overlay) {
-    m_ri->m_guard_zone[1]->SearchTargets();
-  }
-}
 
 void ArpaTarget::RefreshTarget(int dist) {
   Position prev_X;


### PR DESCRIPTION
When in preferences "guardzone on overlay" = off, no targets are searched for in guardzone on radarwindow.
Corrected here.