### PR TITLE
AISinARPA as vector to save space and avoid possible restriction in n…

### DIFF
--- a/src/br24radar_pi.cpp
+++ b/src/br24radar_pi.cpp
@@ -1555,7 +1555,7 @@ void br24radar_pi::SetPluginMessage(wxString &message_id, wxString &message_body
         }
       }
     }
-  } else if (message_id == wxS("AIS") || AISinARPAzone.size() > 0) {
+  } else if (message_id == wxS("AIS") || m_ais_in_arpa_zone.size() > 0) {
     // Check if any Radar and ARPA zone is active
     double ArpaMaxRange = 0.0;
     bool ArpaGuardOn = false;
@@ -1588,32 +1588,32 @@ void br24radar_pi::SetPluginMessage(wxString &message_id, wxString &message_body
           if (f_AISLat < (m_radar_lat + d_side) && f_AISLat > (m_radar_lat - d_side) && f_AISLon < (m_radar_lon + d_side * 2) &&
               f_AISLon > (m_radar_lon - d_side * 2)) {
             bool updated = false;
-            for (size_t i = 0; i < AISinARPAzone.size(); i++) { //Check for existing mmsi
-                if (AISinARPAzone[i].ais_mmsi == json_ais_mmsi) {
-                    AISinARPAzone[i].ais_time_upd = time(0);
-                    AISinARPAzone[i].ais_lat = f_AISLat;
-                    AISinARPAzone[i].ais_lon = f_AISLon;
+            for (size_t i = 0; i < m_ais_in_arpa_zone.size(); i++) { //Check for existing mmsi
+                if (m_ais_in_arpa_zone[i].ais_mmsi == json_ais_mmsi) {
+                    m_ais_in_arpa_zone[i].ais_time_upd = time(0);
+                    m_ais_in_arpa_zone[i].ais_lat = f_AISLat;
+                    m_ais_in_arpa_zone[i].ais_lon = f_AISLon;
                     updated = true;
                     break;
                 }
             }
             if (!updated) { //Add a new target
-                AisArpa NewAISTarget;
-                NewAISTarget.ais_mmsi = json_ais_mmsi;
-                NewAISTarget.ais_time_upd = time(0);
-                NewAISTarget.ais_lat = f_AISLat;
-                NewAISTarget.ais_lon = f_AISLon;
-                AISinARPAzone.push_back(NewAISTarget);
+                AisArpa m_new_ais_target;
+                m_new_ais_target.ais_mmsi = json_ais_mmsi;
+                m_new_ais_target.ais_time_upd = time(0);
+                m_new_ais_target.ais_lat = f_AISLat;
+                m_new_ais_target.ais_lon = f_AISLon;
+                m_ais_in_arpa_zone.push_back(m_new_ais_target);
             }
           }
         }
       }
     }
     // Delete > 3 min old AIS items or at once if neither active ARPA zone nor Radar
-    if (AISinARPAzone.size() > 0) {
-        for (size_t i = 0; i < AISinARPAzone.size(); i++) {
-            if (AISinARPAzone[i].ais_mmsi > 0 && ((time(0) - AISinARPAzone[i].ais_time_upd) > (3 * 60) || !ArpaGuardOn)) {
-                AISinARPAzone.erase(AISinARPAzone.begin() + i);
+    if (m_ais_in_arpa_zone.size() > 0) {
+        for (size_t i = 0; i < m_ais_in_arpa_zone.size(); i++) {
+            if (m_ais_in_arpa_zone[i].ais_mmsi > 0 && ((time(0) - m_ais_in_arpa_zone[i].ais_time_upd) > (3 * 60) || !ArpaGuardOn)) {
+                m_ais_in_arpa_zone.erase(m_ais_in_arpa_zone.begin() + i);
             }
         }
     }
@@ -1621,13 +1621,13 @@ void br24radar_pi::SetPluginMessage(wxString &message_id, wxString &message_body
 }
 
 bool br24radar_pi::FindAIS_at_arpaPos(const double &lat, const double &lon, const double &dist) {
-  if (AISinARPAzone.size() < 1) return false;
+  if (m_ais_in_arpa_zone.size() < 1) return false;
   bool hit = false;
   double offset = dist / 1852. / 60.;
-  for (size_t i = 0; i < AISinARPAzone.size(); i++) {
-      if (AISinARPAzone[i].ais_mmsi != 0) {  // Avtive post
-          if (lat + offset > AISinARPAzone[i].ais_lat && lat - offset < AISinARPAzone[i].ais_lat &&
-              lon + (offset * 1.75) > AISinARPAzone[i].ais_lon && lon - (offset * 1.75) < AISinARPAzone[i].ais_lon) {
+  for (size_t i = 0; i < m_ais_in_arpa_zone.size(); i++) {
+      if (m_ais_in_arpa_zone[i].ais_mmsi != 0) {  // Avtive post
+          if (lat + offset > m_ais_in_arpa_zone[i].ais_lat && lat - offset < m_ais_in_arpa_zone[i].ais_lat &&
+              lon + (offset * 1.75) > m_ais_in_arpa_zone[i].ais_lon && lon - (offset * 1.75) < m_ais_in_arpa_zone[i].ais_lon) {
         hit = true;
         break;
       }

--- a/src/br24radar_pi.h
+++ b/src/br24radar_pi.h
@@ -502,7 +502,7 @@ class br24radar_pi : public opencpn_plugin_114, public wxEvtHandler {
   time_t m_idle_transmit;  // When we will change to transmit
 
   // Check for AIS targets inside ARPA zone
-  vector<AisArpa> AISinARPAzone; //Array for AIS targets in ARPA zone(s)
+  vector<AisArpa> m_ais_in_arpa_zone; //Array for AIS targets in ARPA zone(s)
   bool FindAIS_at_arpaPos(const double &lat, const double &lon, const double &dist);
 
  private:

--- a/src/br24radar_pi.h
+++ b/src/br24radar_pi.h
@@ -39,6 +39,7 @@
 #include "nmea0183/nmea0183.h"
 #include "pi_common.h"
 #include "version.h"
+#include <vector>
 
 // Load the ocpn_plugin. On OS X this generates many warnings, suppress these.
 #ifdef __WXOSX__
@@ -352,12 +353,14 @@ struct scan_line {
 };
 
 // Table for AIS targets inside ARPA zone
-#define SIZEAISAR (50)
 struct AisArpa {
-  long ais_mmsi;
-  time_t ais_time_upd;
-  double ais_lat;
-  double ais_lon;
+    long ais_mmsi;
+    time_t ais_time_upd;
+    double ais_lat;
+    double ais_lon;
+
+    AisArpa()
+    : ais_mmsi(0), ais_time_upd(), ais_lat(), ais_lon() {}
 };
 
 //----------------------------------------------------------------------------------------------------------
@@ -499,8 +502,7 @@ class br24radar_pi : public opencpn_plugin_114, public wxEvtHandler {
   time_t m_idle_transmit;  // When we will change to transmit
 
   // Check for AIS targets inside ARPA zone
-  AisArpa ais_in_arpa[SIZEAISAR];
-  int count_ais_in_arpa;
+  vector<AisArpa> AISinARPAzone; //Array for AIS targets in ARPA zone(s)
   bool FindAIS_at_arpaPos(const double &lat, const double &lon, const double &dist);
 
  private:


### PR DESCRIPTION
…umber of targets.

Kees.

This change is made for three reasons:
- A vector array is not defined from start and thus takes not  more memory then needed.
- The array size is not limited and thus always big enough.
- Third and not less; My first lesson on using struct - vector so combined with the above features it was fun.
BUT -  Please check if vectors like this is able to use in our plugin. The #include <vector> is not used before. Is there a reason for that? I've built and run it on Win10. It's built and run on Linux/Rasbian but I've no OSX so not tested there.
Your comments/criticism are very welcome and if this change is not feasible please do not merge it. Instead I'll appreciate your experienced advice.
Håkan